### PR TITLE
Fix business logic

### DIFF
--- a/Levi9_competition/Levi9_competition/Controllers/PlayerController.cs
+++ b/Levi9_competition/Levi9_competition/Controllers/PlayerController.cs
@@ -68,7 +68,7 @@ namespace Levi9_competition.Controllers
         public async Task<IActionResult> DeleteAllData()
         {
             await _playerService.DeleteAllDataAsync();
-            return NoContent();
+            return Ok();
         }
 
         [HttpPut]

--- a/Levi9_competition/Levi9_competition/Services/MatchService.cs
+++ b/Levi9_competition/Levi9_competition/Services/MatchService.cs
@@ -77,13 +77,13 @@ namespace Levi9_competition.Services
             foreach (var player in players)
             {
                 double expectedScore = CalculateExpectedScore(player.Elo, opponentElo);
-                int k = CalculateK(player.HoursPlayed);
-
-                player.Elo = (int)Math.Round(player.Elo + k * (score - expectedScore));
                 player.HoursPlayed += duration;
-
+                int k = CalculateK(player.HoursPlayed);
                 int k2 = CalculateK(player.HoursPlayed);
                 player.RatingAdjustment = k2;
+
+                player.Elo = (int)Math.Round(player.Elo + k * (score - expectedScore));
+
 
                 if (score == 1)
                 {


### PR DESCRIPTION
This pull request includes changes to improve the response status in the `PlayerController` and adjust the order of operations in the `MatchService`. The most important changes include modifying the return status of the `DeleteAllData` method and reordering the updates to player attributes in the `UpdateTeamPlayers` method.

Improvements to response status:

* [`Levi9_competition/Levi9_competition/Controllers/PlayerController.cs`](diffhunk://#diff-4f901e4b07b8b9e6ac3a80e770ef9b3be90f739717a33dc1d5bc059b435323faL71-R71): Changed the return status of `DeleteAllData` from `NoContent()` to `Ok()`.

Reordering updates to player attributes:

* [`Levi9_competition/Levi9_competition/Services/MatchService.cs`](diffhunk://#diff-b14e3a1bd142c6a005793bf13bde47e5c5172541c192595114a49a02ef2b8821R80-L86): Reordered the updates to `player.HoursPlayed` and `player.RatingAdjustment` to ensure `HoursPlayed` is updated before recalculating `RatingAdjustment`.